### PR TITLE
Support ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
   "repository": "https://github.com/simplabs/qunit-dom",
   "license": "MIT",
   "author": "simplabs GmbH",
+  "exports": {
+    ".": {
+      "import": "./dist/addon-test-support/index.js"
+    }
+  },
   "types": "dist/qunit-dom.d.ts",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
today, qunit-dom's default path points to the wrong file.

in a real ESM environment, `import * as anything from 'qunit-dom'` points at the ember addon index.js instead of anything useful.

I've been working towards getting v2 addon testing to be much less a pain in the butt, so I'm going full ESM with Vite (which I know will require a bunch of work when I get to dealing with the emberisms), but qnuit-dom should probably be compatible with ESM environments anyway. Here is the patch I made here: https://github.com/NullVoxPopuli/ember-resources/pull/585/files#diff-654ac9908e210063f32fb8d67f4742e747b8b19fd85f087b265fe81147eda554
Some proof: 
![image](https://user-images.githubusercontent.com/199018/184432945-84f9469d-3f61-40e6-bd63-09beb5edc3ab.png)


