### PR TITLE
Add `HTMLLinkElement` as eligible `.disabled` element

### DIFF
--- a/lib/assertions/is-disabled.ts
+++ b/lib/assertions/is-disabled.ts
@@ -12,7 +12,8 @@ export default function isDisabled(message?: string, options: { inverted?: boole
       element instanceof HTMLButtonElement ||
       element instanceof HTMLOptGroupElement ||
       element instanceof HTMLOptionElement ||
-      element instanceof HTMLFieldSetElement
+      element instanceof HTMLFieldSetElement ||
+      element instanceof HTMLLinkElement
     )
   ) {
     throw new TypeError(`Unexpected Element Type: ${element.toString()}`);


### PR DESCRIPTION
When trying to write tests for a `HTMLLinkElement` and check for `.disabled` state, instead of asserting, `qunit-dom` throw an error.

There is a little gotcha for `disabled` on `<link>`.

- As per declarative API ([`<link disabled>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-disabled)), this is experimental, deprecated and advised against its usage (and also does not work in browsers)
- As per imperative API ([`HTMLLinkElement.disabled`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLLinkElement#htmllinkelement.disabled)), this is according to MDN allow _and works in browsers_

So, this PR adds `HTMLLinkElement` as eligible element to check this for 😃 