### PR TITLE
Use getProperty for hasStyle assertions so testing can be done against css variables

### DIFF
--- a/lib/__tests__/has-style.ts
+++ b/lib/__tests__/has-style.ts
@@ -8,7 +8,10 @@ describe('assert.dom(...).hasStyle()', () => {
   beforeEach(() => {
     assert = new TestAssertions();
     document.body.innerHTML =
-      '<div class="foo" style="opacity: 1; width: 200px; text-align: center;">quit-dom ftw!</div>';
+      '<div class="foo" style="opacity: 1; width: 200px; text-align: center; --color-text: #FFF;">quit-dom ftw!</div>';
+
+    //@ts-ignore
+    document.querySelector('.foo').style.setProperty('--color-background', '#333');
   });
 
   test('succeeds for correct content', () => {
@@ -58,6 +61,22 @@ describe('assert.dom(...).hasStyle()', () => {
         actual: { opacity: '1' },
         expected: { opacity: '1' },
         message: 'Element .foo has style "{"opacity":"1"}"',
+        result: true,
+      },
+    ]);
+  });
+
+  test('succeeds for custom property', () => {
+    assert.dom('.foo').hasStyle({
+      '--color-text': '#FFF',
+      '--color-background': '#333',
+    });
+
+    expect(assert.results).toEqual([
+      {
+        actual: { '--color-text': '#FFF', '--color-background': '#333' },
+        expected: { '--color-text': '#FFF', '--color-background': '#333' },
+        message: 'Element .foo has style "{"--color-text":"#FFF","--color-background":"#333"}"',
         result: true,
       },
     ]);
@@ -120,4 +139,5 @@ describe('assert.dom(...).hasStyle()', () => {
 
     expect(assert.results.length).toEqual(2);
   });
+
 });

--- a/lib/assertions.ts
+++ b/lib/assertions.ts
@@ -774,11 +774,13 @@ export default class DOMAssertions {
     }
 
     let result = expectedProperties.every(
-      property => computedStyle[property] === expected[property]
+      property => computedStyle.getPropertyValue(property.toString()) === expected[property]
     );
     let actual: ActualCSSStyleDeclaration = {};
 
-    expectedProperties.forEach(property => (actual[property] = computedStyle[property]));
+    expectedProperties.forEach(
+      property => (actual[property] = computedStyle.getPropertyValue(property.toString()))
+    );
 
     if (!message) {
       let normalizedSelector = selector ? selector.replace(/^:{0,2}/, '::') : '';


### PR DESCRIPTION
As described in #1972, qunit-dom doesn't currently have the ability to check css variables. This PR adds that ability.