### PR TITLE
v3 RC: TS: Fix `Assert` types.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This will attach the APIs to QUnit's `assert` object.
 
 ### Ember projects using &lt; v6.x of ember-qunit
 
-Install qunit-dom v2.0.0
+Install qunit-dom v3.0.0
 
 ### `<script>` Tag
 
@@ -69,7 +69,7 @@ Load `qunit-dom.js` *after* `qunit.js`:
 
 ```html
 <script src="https://unpkg.com/qunitjs/qunit/qunit.js"></script>
-<script src="https://unpkg.com/qunit-dom/dist/qunit-dom.js"></script>
+<script src="https://unpkg.com/qunit-dom/dist/iife/qunit-dom.js"></script>
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Load `qunit-dom.js` *after* `qunit.js`:
 
 ```html
 <script src="https://unpkg.com/qunitjs/qunit/qunit.js"></script>
-<script src="https://unpkg.com/qunit-dom/dist/iife/qunit-dom.js"></script>
+<script src="https://unpkg.com/qunit-dom/dist/qunit-dom.js"></script>
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This will attach the APIs to QUnit's `assert` object.
 
 ### Ember projects using &lt; v6.x of ember-qunit
 
-Install qunit-dom v3.0.0
+Install qunit-dom v2.0.0
 
 ### `<script>` Tag
 

--- a/packages/qunit-dom/lib/install.ts
+++ b/packages/qunit-dom/lib/install.ts
@@ -1,6 +1,12 @@
 import DOMAssertions from './assertions';
 import { getRootElement } from './root-element';
 
+declare global {
+  interface Assert {
+    dom(target?: string | Element | null, rootElement?: Element): DOMAssertions;
+  }
+}
+
 export default function (assert: Assert) {
   assert.dom = function (target?: string | Element | null, rootElement?: Element): DOMAssertions {
     if (!isValidRootElement(rootElement)) {

--- a/packages/qunit-dom/lib/qunit-dom.ts
+++ b/packages/qunit-dom/lib/qunit-dom.ts
@@ -1,14 +1,6 @@
 /* global QUnit */
-
-import type DOMAssertions from './assertions';
 import install from './install';
 
 export { setup } from './qunit-dom-modules';
-
-declare global {
-  interface Assert {
-    dom(target?: string | Element | null, rootElement?: Element): DOMAssertions;
-  }
-}
 
 install(QUnit.assert);

--- a/packages/qunit-dom/package.json
+++ b/packages/qunit-dom/package.json
@@ -16,16 +16,16 @@
   "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/addon-test-support/qunit-dom-modules.d.ts",
-      "default": "./dist/addon-test-support/index.js"
+      "types": "./dist/es/qunit-dom.d.ts",
+      "default": "./dist/es/index.js"
     }
   },
   "typesVersions": {
     "*": {
-      "*": "dist/addon-test-support/qunit-dom-modules.d.ts"
+      "*": "dist/es/qunit-dom.d.ts"
     }
   },
-  "types": "dist/qunit-dom.d.ts",
+  "types": "dist/es/qunit-dom.d.ts",
   "files": [
     "dist"
   ],

--- a/packages/qunit-dom/rollup.config.mjs
+++ b/packages/qunit-dom/rollup.config.mjs
@@ -25,7 +25,7 @@ const iifeBundle = {
 
   output: {
     name: 'QUnitDOM',
-    file: 'dist/qunit-dom.js',
+    file: 'dist/iife/index.js',
     format: 'iife',
     sourcemap: true,
   },
@@ -38,7 +38,7 @@ const esBundle = {
   plugins: [typescript(typescriptConfiguration)],
 
   output: {
-    file: 'dist/addon-test-support/index.js',
+    file: 'dist/es/index.js',
     format: 'es',
     sourcemap: true,
   },

--- a/packages/qunit-dom/rollup.config.mjs
+++ b/packages/qunit-dom/rollup.config.mjs
@@ -21,11 +21,18 @@ const iifeBundle = {
   input: 'lib/qunit-dom.ts',
 
   external: ['qunit'],
-  plugins: [typescript(typescriptConfiguration), copyStaticArtifacts],
+  plugins: [typescript({
+    ...typescriptConfiguration,
+    tsconfigOverride: {
+      compilerOptions: {
+        declaration: false,
+      }
+    }
+  }), copyStaticArtifacts],
 
   output: {
     name: 'QUnitDOM',
-    file: 'dist/iife/index.js',
+    file: 'dist/qunit-dom.js',
     format: 'iife',
     sourcemap: true,
   },


### PR DESCRIPTION
at some point in the shuffle the `declare global {}` interface merge stopped working.

as I dug in to it, I noticed that the `declare global` was discarded for the iife build, but retained in the ES build.

as part of this process i put the es output in its own folder.
then disabled the declarations output for iife.

this is a non-breaking change

<details><summary>previously</summary>

As a result, I've split rollup's output files into sub-folders of `dist`, `es` and `iife`.

We don't _need_ to split both (iife could still be the root of `dist`, for example), but they do need to be separate from each other so they don't stomp on eachother's emitted files.

_right now_, here is how the output looks: 
![image](https://github.com/mainmatter/qunit-dom/assets/199018/61ce0674-dafb-4b59-9642-e7ae1a3eaf6e)

a bunch of the .d.ts files are duplicated, but I was thinking about maybe cleaning those up from the iife output in a separate PR, leaving just the index.js, since we don't need separate types for the iife use case


</details>