### PR TITLE
chore(ci): use volta-cli github action for node and pnpm setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
     - cron: '0 3 * * *' # daily, at 3am
 
 env:
-  PNPM_VERSION: 8.8.0
+  VOLTA_FEATURE_PNPM: 1
 
 jobs:
   docs:
@@ -18,15 +18,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.0
-      - uses: pnpm/action-setup@v2.4.0
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      - uses: volta-cli/action@d253558a6e356722728a10e9a469190de21a83ef # v4
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3
         with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - uses: actions/setup-node@v3.8.1
-        with:
-          node-version: 18.17
-          cache: pnpm
+          path: "**/node_modules"
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
 
       - run: pnpm install
       - run: pnpm run docs
@@ -39,15 +38,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.0
-      - uses: pnpm/action-setup@v2.4.0
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      - uses: volta-cli/action@d253558a6e356722728a10e9a469190de21a83ef # v4
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3
         with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - uses: actions/setup-node@v3.8.1
-        with:
-          node-version: 18.17
-          cache: pnpm
+          path: "**/node_modules"
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
 
       - run: pnpm install
       - run: pnpm build
@@ -67,15 +65,14 @@ jobs:
           - ember-lts-4.12
 
     steps:
-      - uses: actions/checkout@v4.1.0
-      - uses: pnpm/action-setup@v2.4.0
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      - uses: volta-cli/action@d253558a6e356722728a10e9a469190de21a83ef # v4
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3
         with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - uses: actions/setup-node@v3.8.1
-        with:
-          node-version: 18.17
-          cache: pnpm
+          path: "**/node_modules"
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
 
       - run: pnpm install
       - run: pnpm build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
       - 'v*'
 
 env:
-  PNPM_VERSION: 8.8.0
+  VOLTA_FEATURE_PNPM: 1
 
 jobs:
   release:
@@ -14,22 +14,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4.1.0
-      - uses: pnpm/action-setup@v2.4.0
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+      - uses: volta-cli/action@d253558a6e356722728a10e9a469190de21a83ef # v4
+      - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 # v3
         with:
-          version: ${{ env.PNPM_VERSION }}
-
-      - uses: actions/setup-node@v3.8.1
-        with:
-          node-version: 18.17
-          registry-url: 'https://registry.npmjs.org'
-          cache: pnpm
-
+          path: "**/node_modules"
+          key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-
       - run: pnpm install
       - run: pnpm build
 
       - name: auto-dist-tag
-        run: npx auto-dist-tag@1 --write
+        run: pnpm dlx auto-dist-tag@1 --write
         working-directory: packages/qunit-dom
 
       - run: npm publish


### PR DESCRIPTION
- Changes github action workflows to use volta-cli for node and pnpm setup.