### PR TITLE
v3: Maximize compatibility

### DIFF
--- a/packages/qunit-dom/lib/assertions.ts
+++ b/packages/qunit-dom/lib/assertions.ts
@@ -1,17 +1,17 @@
-import exists from './assertions/exists';
-import focused from './assertions/focused';
-import notFocused from './assertions/not-focused';
-import isChecked from './assertions/is-checked';
-import isNotChecked from './assertions/is-not-checked';
-import isRequired from './assertions/is-required';
-import isNotRequired from './assertions/is-not-required';
-import isValid from './assertions/is-valid';
-import isVisible from './assertions/is-visible';
-import isDisabled from './assertions/is-disabled';
-import matchesSelector from './assertions/matches-selector';
-import elementToString from './helpers/element-to-string';
-import collapseWhitespace from './helpers/collapse-whitespace';
-import { toArray } from './helpers/node-list';
+import exists from './assertions/exists.js';
+import focused from './assertions/focused.js';
+import notFocused from './assertions/not-focused.js';
+import isChecked from './assertions/is-checked.js';
+import isNotChecked from './assertions/is-not-checked.js';
+import isRequired from './assertions/is-required.js';
+import isNotRequired from './assertions/is-not-required.js';
+import isValid from './assertions/is-valid.js';
+import isVisible from './assertions/is-visible.js';
+import isDisabled from './assertions/is-disabled.js';
+import matchesSelector from './assertions/matches-selector.js';
+import elementToString from './helpers/element-to-string.js';
+import collapseWhitespace from './helpers/collapse-whitespace.js';
+import { toArray } from './helpers/node-list.js';
 
 export interface AssertionResult {
   result: boolean;

--- a/packages/qunit-dom/lib/assertions/exists.ts
+++ b/packages/qunit-dom/lib/assertions/exists.ts
@@ -1,4 +1,4 @@
-import { ExistsOptions } from '../assertions';
+import type { ExistsOptions } from '../assertions.js';
 
 export default function exists(options?: ExistsOptions | string, message?: string) {
   let expectedCount: number | null = null;

--- a/packages/qunit-dom/lib/assertions/focused.ts
+++ b/packages/qunit-dom/lib/assertions/focused.ts
@@ -1,4 +1,4 @@
-import elementToString from '../helpers/element-to-string';
+import elementToString from '../helpers/element-to-string.js';
 
 export default function focused(message?: string) {
   let element = this.findTargetElement();

--- a/packages/qunit-dom/lib/assertions/is-checked.ts
+++ b/packages/qunit-dom/lib/assertions/is-checked.ts
@@ -1,4 +1,4 @@
-import elementToString from '../helpers/element-to-string';
+import elementToString from '../helpers/element-to-string.js';
 
 export default function checked(message?: string) {
   let element = this.findTargetElement();

--- a/packages/qunit-dom/lib/assertions/is-not-checked.ts
+++ b/packages/qunit-dom/lib/assertions/is-not-checked.ts
@@ -1,4 +1,4 @@
-import elementToString from '../helpers/element-to-string';
+import elementToString from '../helpers/element-to-string.js';
 
 export default function notChecked(message?: string) {
   let element = this.findTargetElement();

--- a/packages/qunit-dom/lib/assertions/is-not-required.ts
+++ b/packages/qunit-dom/lib/assertions/is-not-required.ts
@@ -1,4 +1,4 @@
-import elementToString from '../helpers/element-to-string';
+import elementToString from '../helpers/element-to-string.js';
 
 export default function notRequired(message?: string) {
   let element = this.findTargetElement();

--- a/packages/qunit-dom/lib/assertions/is-required.ts
+++ b/packages/qunit-dom/lib/assertions/is-required.ts
@@ -1,4 +1,4 @@
-import elementToString from '../helpers/element-to-string';
+import elementToString from '../helpers/element-to-string.js';
 
 export default function required(message?: string) {
   let element = this.findTargetElement();

--- a/packages/qunit-dom/lib/assertions/is-valid.ts
+++ b/packages/qunit-dom/lib/assertions/is-valid.ts
@@ -1,4 +1,4 @@
-import elementToString from '../helpers/element-to-string';
+import elementToString from '../helpers/element-to-string.js';
 
 export default function isValid(message?: string, options: { inverted?: boolean } = {}) {
   let element = this.findTargetElement();

--- a/packages/qunit-dom/lib/assertions/is-visible.ts
+++ b/packages/qunit-dom/lib/assertions/is-visible.ts
@@ -1,5 +1,5 @@
-import visible from '../helpers/visible';
-import { ExistsOptions } from '../assertions';
+import visible from '../helpers/visible.js';
+import type { ExistsOptions } from '../assertions.js';
 
 export default function isVisible(options?: string | ExistsOptions, message?: string) {
   let expectedCount: number | null = null;

--- a/packages/qunit-dom/lib/helpers/test-assertions.ts
+++ b/packages/qunit-dom/lib/helpers/test-assertions.ts
@@ -1,4 +1,4 @@
-import DOMAssertions, { AssertionResult } from '../assertions';
+import DOMAssertions, { type AssertionResult } from '../assertions.js';
 
 export default class TestAssertions {
   public results: AssertionResult[] = [];

--- a/packages/qunit-dom/lib/install.ts
+++ b/packages/qunit-dom/lib/install.ts
@@ -1,5 +1,5 @@
-import DOMAssertions from './assertions';
-import { getRootElement } from './root-element';
+import DOMAssertions from './assertions.js';
+import { getRootElement } from './root-element.js';
 
 declare global {
   interface Assert {

--- a/packages/qunit-dom/lib/qunit-dom-modules.ts
+++ b/packages/qunit-dom/lib/qunit-dom-modules.ts
@@ -1,7 +1,7 @@
-import install from './install';
-import { overrideRootElement } from './root-element';
+import install from './install.js';
+import { overrideRootElement } from './root-element.js';
 
-export { default as install } from './install';
+export { default as install } from './install.js';
 
 interface SetupOptions {
   getRootElement?: () => Element | null;

--- a/packages/qunit-dom/lib/qunit-dom.ts
+++ b/packages/qunit-dom/lib/qunit-dom.ts
@@ -1,6 +1,6 @@
 /* global QUnit */
-import install from './install';
+import install from './install.js';
 
-export { setup } from './qunit-dom-modules';
+export { setup } from './qunit-dom-modules.js';
 
 install(QUnit.assert);

--- a/packages/qunit-dom/package.json
+++ b/packages/qunit-dom/package.json
@@ -20,11 +20,6 @@
       "default": "./dist/es/index.js"
     }
   },
-  "typesVersions": {
-    "*": {
-      "*": "dist/es/qunit-dom.d.ts"
-    }
-  },
   "types": "dist/es/qunit-dom.d.ts",
   "files": [
     "dist"
@@ -35,7 +30,7 @@
     "lint": "concurrently 'npm:lint:*(!fix)' --names 'lint:'",
     "lint:fix": "concurrently 'npm:lint:*:fix' --names 'fix:'",
     "lint:package": "publint",
-    "lint:published-types": "attw --pack --ignore-rules no-resolution cjs-resolves-to-esm internal-resolution-error",
+    "lint:published-types": "attw --pack --ignore-rules cjs-resolves-to-esm internal-resolution-error",
     "lint:js": "eslint . --cache",
     "lint::js:fix": "eslint . --fix",
     "prepublish": "rollup -c",

--- a/packages/qunit-dom/tsconfig.json
+++ b/packages/qunit-dom/tsconfig.json
@@ -2,6 +2,16 @@
   "compilerOptions": {
     "noImplicitAny": true,
     "declaration": true,
+    // Forces import type when imports are only used as types.
+    "verbatimModuleSyntax": true,
+    // We build to ESM, so we need to tell TS that we build to ESM
+    // otherwise TS uses fake ESM (you use imports, but it assumes the compilation is to CJS)
+    // These are also required when using 
+    // verbatimModuleSyntax, because it's an 
+    // ESM-only feature
+    "target": "esnext",
+    "module": "esnext",
+
     "lib": [
       "ES6",
       "DOM"

--- a/packages/test-types-resolution-node/package.json
+++ b/packages/test-types-resolution-node/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "type-tests-resolution-node16",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "tsc --noEmit",
+    "start": "tsc --noEmit --watch",
+    "test": "echo 'run pnpm lint' instead"
+  },
+  "devDependencies": {
+    "@types/qunit": "2.19.6",
+    "expect-type": "^0.17.3",
+    "typescript": "5.2.2"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "dependencies": {
+    "qunit": "^2.20.0",
+    "qunit-dom": "workspace:*"
+  }
+}

--- a/packages/test-types-resolution-node/package.json
+++ b/packages/test-types-resolution-node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "type-tests-resolution-node16",
+  "name": "type-tests-resolution-node",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/test-types-resolution-node/test.ts
+++ b/packages/test-types-resolution-node/test.ts
@@ -1,0 +1,10 @@
+import QUnit from 'qunit';
+import { setup } from 'qunit-dom';
+import { expectTypeOf } from 'expect-type'
+
+setup(QUnit.assert);
+
+expectTypeOf(QUnit.assert.dom).parameter(0).toEqualTypeOf<string | Element | null | undefined>();
+// @ts-expect-error - there is only one parameter
+expectTypeOf(QUnit.assert.dom).parameter(1).toEqualTypeOf<never>();
+

--- a/packages/test-types-resolution-node/tsconfig.json
+++ b/packages/test-types-resolution-node/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    // Settings needed for test
+    "target": "esnext",
+    // using qunit-dom with node would require jsdom or happydom
+    // but these use cases are currently untested.
+    // But some older packagers set up TS this way because they 
+    // haven't moved to the newer "bundler" resolution mode yet.
+    "module": "esnext",
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+
+    /////////////////////////
+    // Settings to help us type check effectively.
+    // Unrelated to the above.
+
+    // Strictness settings (one day default?)
+    "strict": true,
+
+    // Don't implicitly pull in declarations from `@types` packages unless we
+    // actually import from them AND the package in question doesn't bring its
+    // own types. 
+    "types": []
+  }
+}

--- a/packages/test-types-resolution-node16/package.json
+++ b/packages/test-types-resolution-node16/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "type-tests-resolution-node16",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "tsc --noEmit",
+    "start": "tsc --noEmit --watch",
+    "test": "echo 'run pnpm lint' instead"
+  },
+  "devDependencies": {
+    "@types/qunit": "2.19.6",
+    "expect-type": "^0.17.3",
+    "typescript": "5.2.2"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "dependencies": {
+    "qunit": "^2.20.0",
+    "qunit-dom": "workspace:*"
+  }
+}

--- a/packages/test-types-resolution-node16/test.ts
+++ b/packages/test-types-resolution-node16/test.ts
@@ -1,0 +1,10 @@
+import QUnit from 'qunit';
+import { setup } from 'qunit-dom';
+import { expectTypeOf } from 'expect-type'
+
+setup(QUnit.assert);
+
+expectTypeOf(QUnit.assert.dom).parameter(0).toEqualTypeOf<string | Element | null | undefined>();
+// @ts-expect-error - there is only one parameter
+expectTypeOf(QUnit.assert.dom).parameter(1).toEqualTypeOf<never>();
+

--- a/packages/test-types-resolution-node16/tsconfig.json
+++ b/packages/test-types-resolution-node16/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    // Settings needed for test
+    "target": "esnext",
+    // using qunit-dom with node would require jsdom or happydom
+    // but these use cases are currently untested.
+    // Node16+ requires file extensions
+    "module": "Node16",
+    "moduleResolution": "node16",
+
+    /////////////////////////
+    // Settings to help us type check effectively.
+    // Unrelated to the above.
+
+    // Strictness settings (one day default?)
+    "strict": true,
+
+    // Don't implicitly pull in declarations from `@types` packages unless we
+    // actually import from them AND the package in question doesn't bring its
+    // own types. 
+    "types": []
+  }
+}

--- a/packages/test-types/package.json
+++ b/packages/test-types/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "type-tests",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "tsc --noEmit",
+    "start": "tsc --noEmit --watch",
+    "test": "echo 'run pnpm lint' instead"
+  },
+  "devDependencies": {
+    "@types/qunit": "2.19.6",
+    "expect-type": "^0.17.3",
+    "typescript": "5.2.2"
+  },
+  "volta": {
+    "extends": "../../package.json"
+  },
+  "dependencies": {
+    "qunit": "^2.20.0",
+    "qunit-dom": "workspace:*"
+  }
+}

--- a/packages/test-types/test.ts
+++ b/packages/test-types/test.ts
@@ -1,0 +1,10 @@
+import QUnit from 'qunit';
+import { setup } from 'qunit-dom';
+import { expectTypeOf } from 'expect-type'
+
+setup(QUnit.assert);
+
+expectTypeOf(QUnit.assert.dom).parameter(0).toEqualTypeOf<string | Element | null | undefined>();
+// @ts-expect-error - there is only one parameter
+expectTypeOf(QUnit.assert.dom).parameter(1).toEqualTypeOf<never>();
+

--- a/packages/test-types/tsconfig.json
+++ b/packages/test-types/tsconfig.json
@@ -5,9 +5,12 @@
     "module": "esnext",
     "moduleResolution": "bundler",
 
+    /////////////////////////
+    // Settings to help us type check effectively.
+    // Unrelated to the above.
+
     // Strictness settings (one day default?)
     "strict": true,
-    "alwaysStrict": true,
 
     // Don't implicitly pull in declarations from `@types` packages unless we
     // actually import from them AND the package in question doesn't bring its

--- a/packages/test-types/tsconfig.json
+++ b/packages/test-types/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    // Settings needed for test
+    "target": "esnext",
+    "module": "esnext",
+    "moduleResolution": "bundler",
+
+    // Strictness settings (one day default?)
+    "strict": true,
+    "alwaysStrict": true,
+
+    // Don't implicitly pull in declarations from `@types` packages unless we
+    // actually import from them AND the package in question doesn't bring its
+    // own types. 
+    "types": []
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -349,6 +349,25 @@ importers:
         specifier: 5.88.2
         version: 5.88.2
 
+  packages/test-types:
+    dependencies:
+      qunit:
+        specifier: ^2.20.0
+        version: 2.20.0
+      qunit-dom:
+        specifier: workspace:*
+        version: link:../qunit-dom
+    devDependencies:
+      '@types/qunit':
+        specifier: 2.19.6
+        version: 2.19.6
+      expect-type:
+        specifier: ^0.17.3
+        version: 0.17.3
+      typescript:
+        specifier: 5.2.2
+        version: 5.2.2
+
   packages/test-vite-app:
     devDependencies:
       qunit:
@@ -6579,7 +6598,6 @@ packages:
   /commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
-    dev: true
 
   /commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
@@ -8971,6 +8989,11 @@ packages:
       homedir-polyfill: 1.0.3
     dev: true
 
+  /expect-type@0.17.3:
+    resolution: {integrity: sha512-K0ZdZJ97jiAtaOwhEHHz/f0N6Xbj5reRz5g6+5BO7+OvqQ7PMQz0/c8bFSJs1zPotNJL5HJaC6t6lGPEAtGyOw==}
+    engines: {node: '>=12.0.0'}
+    dev: true
+
   /expect@27.5.1:
     resolution: {integrity: sha512-E1q5hSUG2AmYQwQJ041nvgpkODHQvB+RKlB4IYdru6uJsyFTRyZAP463M+1lINorwbqAmUggi6+WwkD8lCS/Dw==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -9874,7 +9897,6 @@ packages:
 
   /globalyzer@0.1.0:
     resolution: {integrity: sha512-40oNTM9UfG6aBmuKxk/giHn5nQ8RVz/SS4Ir6zgzOv9/qC3kKZ9v4etGTcJbEl/NyVQH7FGU7d+X1egr57Md2Q==}
-    dev: true
 
   /globby@10.0.0:
     resolution: {integrity: sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==}
@@ -9929,7 +9951,6 @@ packages:
 
   /globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-    dev: true
 
   /gopd@1.0.1:
     resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
@@ -13305,7 +13326,6 @@ packages:
   /node-watch@0.7.3:
     resolution: {integrity: sha512-3l4E8uMPY1HdMMryPRUAl+oIHtXtyiTlIiESNSVSNxcPfzAFzeTbXFQkZfAwBbo0B1qMSG8nUABx+Gd+YrbKrQ==}
     engines: {node: '>=6'}
-    dev: true
 
   /nopt@3.0.6:
     resolution: {integrity: sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==}
@@ -14345,7 +14365,6 @@ packages:
       commander: 7.2.0
       node-watch: 0.7.3
       tiny-glob: 0.2.9
-    dev: true
 
   /randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -16218,7 +16237,6 @@ packages:
     dependencies:
       globalyzer: 0.1.0
       globrex: 0.1.2
-    dev: true
 
   /tiny-lr@2.0.0:
     resolution: {integrity: sha512-f6nh0VMRvhGx4KCeK1lQ/jaL0Zdb5WdR+Jk8q9OSUQnaSDxAEGH1fgqLZ+cMl5EW3F2MGnCsalBO1IsnnogW1Q==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,6 +368,44 @@ importers:
         specifier: 5.2.2
         version: 5.2.2
 
+  packages/test-types-resolution-node:
+    dependencies:
+      qunit:
+        specifier: ^2.20.0
+        version: 2.20.0
+      qunit-dom:
+        specifier: workspace:*
+        version: link:../qunit-dom
+    devDependencies:
+      '@types/qunit':
+        specifier: 2.19.6
+        version: 2.19.6
+      expect-type:
+        specifier: ^0.17.3
+        version: 0.17.3
+      typescript:
+        specifier: 5.2.2
+        version: 5.2.2
+
+  packages/test-types-resolution-node16:
+    dependencies:
+      qunit:
+        specifier: ^2.20.0
+        version: 2.20.0
+      qunit-dom:
+        specifier: workspace:*
+        version: link:../qunit-dom
+    devDependencies:
+      '@types/qunit':
+        specifier: 2.19.6
+        version: 2.19.6
+      expect-type:
+        specifier: ^0.17.3
+        version: 0.17.3
+      typescript:
+        specifier: 5.2.2
+        version: 5.2.2
+
   packages/test-vite-app:
     devDependencies:
       qunit:


### PR DESCRIPTION
Blocked by: https://github.com/mainmatter/qunit-dom/pull/2066

This is mostly TS focused, as folks have all sorts of different (probably incorrect, or suboptimal) tsconfig.jsons (in part because TS isn't well understood by many, and keeping up is generally hard!)

I've added 3 test apps for serving and quick reference guides for folks trying to figure out TS with qunit / qunit-dom.

Ran in to an issue though.

Jest doesn't support ESM (easly), so I'm going to remove it. Another PR.