### PR TITLE
Switch to Vitest because it supports ESM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
       - run: pnpm install
       - run: pnpm build
       - run: pnpm lint
-      - run: pnpm test:coverage --runInBand
+      - run: pnpm test:coverage
       - run: pnpm test:ember
 
   compatibility:

--- a/packages/qunit-dom/.eslintrc.cjs
+++ b/packages/qunit-dom/.eslintrc.cjs
@@ -10,7 +10,6 @@ module.exports = {
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/eslint-recommended',
-    'plugin:jest/recommended',
     'plugin:prettier/recommended',
   ],
   env: {

--- a/packages/qunit-dom/lib/__tests__/does-not-exist.ts
+++ b/packages/qunit-dom/lib/__tests__/does-not-exist.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/does-not-have-attribute.ts
+++ b/packages/qunit-dom/lib/__tests__/does-not-have-attribute.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/does-not-have-class.ts
+++ b/packages/qunit-dom/lib/__tests__/does-not-have-class.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/does-not-have-style.ts
+++ b/packages/qunit-dom/lib/__tests__/does-not-have-style.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/does-not-have-tagname.ts
+++ b/packages/qunit-dom/lib/__tests__/does-not-have-tagname.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/does-not-include-text.ts
+++ b/packages/qunit-dom/lib/__tests__/does-not-include-text.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/does-not-match-selector.ts
+++ b/packages/qunit-dom/lib/__tests__/does-not-match-selector.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/exists.ts
+++ b/packages/qunit-dom/lib/__tests__/exists.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/has-any-text.ts
+++ b/packages/qunit-dom/lib/__tests__/has-any-text.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/has-any-value.ts
+++ b/packages/qunit-dom/lib/__tests__/has-any-value.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/has-aria.ts
+++ b/packages/qunit-dom/lib/__tests__/has-aria.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/has-attribute.ts
+++ b/packages/qunit-dom/lib/__tests__/has-attribute.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/has-class.ts
+++ b/packages/qunit-dom/lib/__tests__/has-class.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/has-no-text.ts
+++ b/packages/qunit-dom/lib/__tests__/has-no-text.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/has-no-value.ts
+++ b/packages/qunit-dom/lib/__tests__/has-no-value.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/has-property.ts
+++ b/packages/qunit-dom/lib/__tests__/has-property.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/has-pseudo-element-style.ts
+++ b/packages/qunit-dom/lib/__tests__/has-pseudo-element-style.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/has-style.ts
+++ b/packages/qunit-dom/lib/__tests__/has-style.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/has-tagname.ts
+++ b/packages/qunit-dom/lib/__tests__/has-tagname.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/has-text-regex.ts
+++ b/packages/qunit-dom/lib/__tests__/has-text-regex.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/has-text.ts
+++ b/packages/qunit-dom/lib/__tests__/has-text.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/has-value.ts
+++ b/packages/qunit-dom/lib/__tests__/has-value.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/includes-text.ts
+++ b/packages/qunit-dom/lib/__tests__/includes-text.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect, vi } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 
@@ -142,7 +142,7 @@ describe('assert.dom(...).includesText()', () => {
     });
 
     test('explains failures to the user via `console.warn` if expected text contains collapsable whitespace', () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
       assert.dom(element).includesText('foo\n  bar');
 

--- a/packages/qunit-dom/lib/__tests__/is-checked.ts
+++ b/packages/qunit-dom/lib/__tests__/is-checked.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/is-disabled.ts
+++ b/packages/qunit-dom/lib/__tests__/is-disabled.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/is-focused.ts
+++ b/packages/qunit-dom/lib/__tests__/is-focused.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/is-not-checked.ts
+++ b/packages/qunit-dom/lib/__tests__/is-not-checked.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/is-not-disabled.ts
+++ b/packages/qunit-dom/lib/__tests__/is-not-disabled.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/is-not-focused.ts
+++ b/packages/qunit-dom/lib/__tests__/is-not-focused.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/is-not-required.ts
+++ b/packages/qunit-dom/lib/__tests__/is-not-required.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/is-not-valid.ts
+++ b/packages/qunit-dom/lib/__tests__/is-not-valid.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).isNotValid()', () => {

--- a/packages/qunit-dom/lib/__tests__/is-not-visible.ts
+++ b/packages/qunit-dom/lib/__tests__/is-not-visible.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/is-required.ts
+++ b/packages/qunit-dom/lib/__tests__/is-required.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/is-valid.ts
+++ b/packages/qunit-dom/lib/__tests__/is-valid.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 import TestAssertions from '../helpers/test-assertions';
 
 describe('assert.dom(...).isValid()', () => {

--- a/packages/qunit-dom/lib/__tests__/is-visible.ts
+++ b/packages/qunit-dom/lib/__tests__/is-visible.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/__tests__/matches-selector.ts
+++ b/packages/qunit-dom/lib/__tests__/matches-selector.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import TestAssertions from '../helpers/test-assertions';
 

--- a/packages/qunit-dom/lib/helpers/__tests__/node-list.ts
+++ b/packages/qunit-dom/lib/helpers/__tests__/node-list.ts
@@ -1,3 +1,5 @@
+import { describe, test, expect } from 'vitest';
+
 import * as NodeList from '../node-list';
 
 describe('NodeList helpers', () => {

--- a/packages/qunit-dom/lib/helpers/collapse-whitespace.test.ts
+++ b/packages/qunit-dom/lib/helpers/collapse-whitespace.test.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import collapseWhitespace from './collapse-whitespace';
 

--- a/packages/qunit-dom/lib/helpers/element-to-string.test.ts
+++ b/packages/qunit-dom/lib/helpers/element-to-string.test.ts
@@ -1,4 +1,4 @@
-/* eslint-env jest */
+import { describe, beforeEach, test, expect } from 'vitest';
 
 import elToString from './element-to-string';
 

--- a/packages/qunit-dom/package.json
+++ b/packages/qunit-dom/package.json
@@ -40,21 +40,11 @@
     "lint::js:fix": "eslint . --fix",
     "prepublish": "rollup -c",
     "release": "release-it",
-    "test": "jest",
-    "test:coverage": "jest --coverage",
-    "test:watch": "jest --watchAll --notify"
-  },
-  "jest": {
-    "testEnvironment": "jsdom",
-    "preset": "ts-jest",
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/dist/"
-    ]
+    "test": "vitest",
+    "test:coverage": "vitest --coverage"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.11.0",
-    "@types/jest": "27.5.2",
     "@types/qunit": "2.19.6",
     "@typescript-eslint/eslint-plugin": "6.7.4",
     "@typescript-eslint/parser": "6.7.4",
@@ -63,9 +53,7 @@
     "concurrently": "8.2.1",
     "eslint": "8.50.0",
     "eslint-config-prettier": "9.0.0",
-    "eslint-plugin-jest": "27.4.2",
     "eslint-plugin-prettier": "5.0.0",
-    "jest": "27.5.1",
     "lerna-changelog": "2.2.0",
     "loader.js": "4.7.0",
     "prettier": "3.0.3",
@@ -76,8 +64,8 @@
     "rollup": "2.79.1",
     "rollup-plugin-copy": "3.5.0",
     "rollup-plugin-typescript2": "0.34.1",
-    "ts-jest": "27.1.5",
     "typescript": "5.2.2",
+    "vitest": "^0.34.6",
     "webpack": "5.88.2"
   },
   "packageManager": "pnpm@8.8.0",

--- a/packages/qunit-dom/package.json
+++ b/packages/qunit-dom/package.json
@@ -48,6 +48,7 @@
     "@types/qunit": "2.19.6",
     "@typescript-eslint/eslint-plugin": "6.7.4",
     "@typescript-eslint/parser": "6.7.4",
+    "@vitest/coverage-v8": "^0.34.6",
     "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
     "babel-preset-env": "1.7.0",
     "concurrently": "8.2.1",

--- a/packages/qunit-dom/vitest.config.ts
+++ b/packages/qunit-dom/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    include: ['**/*.test.ts', '**/__tests__/**/*.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: 6.7.4
         version: 6.7.4(eslint@8.50.0)(typescript@5.2.2)
+      '@vitest/coverage-v8':
+        specifier: ^0.34.6
+        version: 0.34.6(vitest@0.34.6)
       babel-plugin-transform-es2015-modules-commonjs:
         specifier: 6.26.2
         version: 6.26.2(supports-color@8.1.1)
@@ -3806,6 +3809,27 @@ packages:
     dependencies:
       '@typescript-eslint/types': 6.7.4
       eslint-visitor-keys: 3.4.3
+    dev: true
+
+  /@vitest/coverage-v8@0.34.6(vitest@0.34.6):
+    resolution: {integrity: sha512-fivy/OK2d/EsJFoEoxHFEnNGTg+MmdZBAVK9Ka4qhXR2K3J0DS08vcGVwzDtXSuUMabLv4KtPcpSKkcMXFDViw==}
+    peerDependencies:
+      vitest: '>=0.32.0 <1'
+    dependencies:
+      '@ampproject/remapping': 2.2.1
+      '@bcoe/v8-coverage': 0.2.3
+      istanbul-lib-coverage: 3.2.0
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 4.0.1
+      istanbul-reports: 3.1.6
+      magic-string: 0.30.4
+      picocolors: 1.0.0
+      std-env: 3.4.3
+      test-exclude: 6.0.0
+      v8-to-istanbul: 9.1.3
+      vitest: 0.34.6
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /@vitest/expect@0.34.6:
@@ -16856,6 +16880,15 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.4
       convert-source-map: 1.9.0
       source-map: 0.7.4
+    dev: true
+
+  /v8-to-istanbul@9.1.3:
+    resolution: {integrity: sha512-9lDD+EVI2fjFsMWXc6dy5JJzBsVTcQ2fVkfBvncZ6xJWG9wtBhOldG+mHkSL0+V1K/xgZz0JDO5UT5hFwHUghg==}
+    engines: {node: '>=10.12.0'}
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.19
+      '@types/istanbul-lib-coverage': 2.0.4
+      convert-source-map: 2.0.0
     dev: true
 
   /validate-npm-package-license@3.0.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,9 +26,6 @@ importers:
       '@arethetypeswrong/cli':
         specifier: 0.11.0
         version: 0.11.0
-      '@types/jest':
-        specifier: 27.5.2
-        version: 27.5.2
       '@types/qunit':
         specifier: 2.19.6
         version: 2.19.6
@@ -53,15 +50,9 @@ importers:
       eslint-config-prettier:
         specifier: 9.0.0
         version: 9.0.0(eslint@8.50.0)
-      eslint-plugin-jest:
-        specifier: 27.4.2
-        version: 27.4.2(@typescript-eslint/eslint-plugin@6.7.4)(eslint@8.50.0)(jest@27.5.1)(typescript@5.2.2)
       eslint-plugin-prettier:
         specifier: 5.0.0
         version: 5.0.0(eslint-config-prettier@9.0.0)(eslint@8.50.0)(prettier@3.0.3)
-      jest:
-        specifier: 27.5.1
-        version: 27.5.1
       lerna-changelog:
         specifier: 2.2.0
         version: 2.2.0
@@ -92,12 +83,12 @@ importers:
       rollup-plugin-typescript2:
         specifier: 0.34.1
         version: 0.34.1(rollup@2.79.1)(typescript@5.2.2)
-      ts-jest:
-        specifier: 27.1.5
-        version: 27.1.5(@babel/core@7.23.0)(@types/jest@27.5.2)(jest@27.5.1)(typescript@5.2.2)
       typescript:
         specifier: 5.2.2
         version: 5.2.2
+      vitest:
+        specifier: ^0.34.6
+        version: 0.34.6
       webpack:
         specifier: 5.88.2
         version: 5.88.2
@@ -365,7 +356,7 @@ importers:
         version: link:../qunit-dom
       vite:
         specifier: 4.4.11
-        version: 4.4.11
+        version: 4.4.11(@types/node@20.8.2)
 
 packages:
 
@@ -2694,6 +2685,13 @@ packages:
       - supports-color
     dev: true
 
+  /@jest/schemas@29.6.3:
+    resolution: {integrity: sha512-mo5j5X+jIZmJQveBKeS/clAueipV7KgiX1vMgCxam1RNYiqE1w62n0/tJJnHtjW8ZHcQco5gY85jA3mi0L+nSA==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@sinclair/typebox': 0.27.8
+    dev: true
+
   /@jest/source-map@27.5.1:
     resolution: {integrity: sha512-y9NIHUYF3PJRlHk98NdC/N1gl88BL08aQQgu4k4ZopQkCw9t9cV8mtl3TV8b/YCB8XaVTFrmUTAJvjsntDireg==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
@@ -3026,6 +3024,10 @@ packages:
     resolution: {integrity: sha512-l5qumKFWU0S+4ZzMaLXFU8tQZsicHEMEyAxI5kDFGhJsRqDwe0a7/iPA/GdxlGyDKseQQAgIz5kzU7eXTrlSpA==}
     dev: true
 
+  /@sinclair/typebox@0.27.8:
+    resolution: {integrity: sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==}
+    dev: true
+
   /@sindresorhus/is@0.14.0:
     resolution: {integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==}
     engines: {node: '>=6'}
@@ -3127,6 +3129,12 @@ packages:
 
   /@types/chai-as-promised@7.1.6:
     resolution: {integrity: sha512-cQLhk8fFarRVZAXUQV1xEnZgMoPxqKojBvRkqPCKPQCzEhpbbSKl1Uu75kDng7k5Ln6LQLUmNBjLlFthCgm1NA==}
+    dependencies:
+      '@types/chai': 4.3.6
+    dev: true
+
+  /@types/chai-subset@1.3.3:
+    resolution: {integrity: sha512-frBecisrNGz+F4T6bcc+NLeolfiojh5FxW2klu669+8BARtyQv2C/GkNW6FUodVe4BroGMP/wER/YDGc7rEllw==}
     dependencies:
       '@types/chai': 4.3.6
     dev: true
@@ -3800,6 +3808,44 @@ packages:
       eslint-visitor-keys: 3.4.3
     dev: true
 
+  /@vitest/expect@0.34.6:
+    resolution: {integrity: sha512-QUzKpUQRc1qC7qdGo7rMK3AkETI7w18gTCUrsNnyjjJKYiuUB9+TQK3QnR1unhCnWRC0AbKv2omLGQDF/mIjOw==}
+    dependencies:
+      '@vitest/spy': 0.34.6
+      '@vitest/utils': 0.34.6
+      chai: 4.3.10
+    dev: true
+
+  /@vitest/runner@0.34.6:
+    resolution: {integrity: sha512-1CUQgtJSLF47NnhN+F9X2ycxUP0kLHQ/JWvNHbeBfwW8CzEGgeskzNnHDyv1ieKTltuR6sdIHV+nmR6kPxQqzQ==}
+    dependencies:
+      '@vitest/utils': 0.34.6
+      p-limit: 4.0.0
+      pathe: 1.1.1
+    dev: true
+
+  /@vitest/snapshot@0.34.6:
+    resolution: {integrity: sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==}
+    dependencies:
+      magic-string: 0.30.4
+      pathe: 1.1.1
+      pretty-format: 29.7.0
+    dev: true
+
+  /@vitest/spy@0.34.6:
+    resolution: {integrity: sha512-xaCvneSaeBw/cz8ySmF7ZwGvL0lBjfvqc1LpQ/vcdHEvpLn3Ff1vAvjw+CoGn0802l++5L/pxb7whwcWAw+DUQ==}
+    dependencies:
+      tinyspy: 2.2.0
+    dev: true
+
+  /@vitest/utils@0.34.6:
+    resolution: {integrity: sha512-IG5aDD8S6zlvloDsnzHw0Ut5xczlF+kv2BOTo+iXfPr54Yhi5qbVOgGB1hZaVq4iJ4C/MZ2J0y15IlsV/ZcI0A==}
+    dependencies:
+      diff-sequences: 29.6.3
+      loupe: 2.3.6
+      pretty-format: 29.7.0
+    dev: true
+
   /@vue/compiler-core@3.3.4:
     resolution: {integrity: sha512-cquyDNvZ6jTbf/+x+AgM2Arrp6G4Dzbb0R64jiG804HRMfRiFXWI6kqUVqZ6ZR0bQhIoQjB4+2bhNtVwndW15g==}
     requiresBuild: true
@@ -4035,6 +4081,11 @@ packages:
 
   /acorn-walk@7.2.0:
     resolution: {integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==}
+    engines: {node: '>=0.4.0'}
+    dev: true
+
+  /acorn-walk@8.2.0:
+    resolution: {integrity: sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==}
     engines: {node: '>=0.4.0'}
     dev: true
 
@@ -4374,6 +4425,10 @@ packages:
 
   /assert-never@1.2.1:
     resolution: {integrity: sha512-TaTivMB6pYI1kXwrFlEhLeGfOqoDNdTxjCdwRfFFkEA30Eu+k48W34nlok2EYWJfFFzqaEmichdNM7th6M5HNw==}
+    dev: true
+
+  /assertion-error@1.1.0:
+    resolution: {integrity: sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==}
     dev: true
 
   /assign-symbols@1.0.0:
@@ -5990,6 +6045,11 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
+  /cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+    dev: true
+
   /cacache@15.3.0:
     resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
     engines: {node: '>= 10'}
@@ -6143,6 +6203,19 @@ packages:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
     dev: true
 
+  /chai@4.3.10:
+    resolution: {integrity: sha512-0UXG04VuVbruMUYbJ6JctvH0YnC/4q3/AkT18q4NaITo91CUm0liMS9VqzT9vZhVQ/1eqPanMWjBM+Juhfb/9g==}
+    engines: {node: '>=4'}
+    dependencies:
+      assertion-error: 1.1.0
+      check-error: 1.0.3
+      deep-eql: 4.1.3
+      get-func-name: 2.0.2
+      loupe: 2.3.6
+      pathval: 1.1.1
+      type-detect: 4.0.8
+    dev: true
+
   /chalk@1.1.3:
     resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
     engines: {node: '>=0.10.0'}
@@ -6201,6 +6274,12 @@ packages:
     resolution: {integrity: sha512-wqW3VdPnlSWT4eRiYX+hcs+C6ViBPUWk1qTCd+37qw9kEm/a5n2qcyQDMBWvSYKN/ctqZzeXNQaeBjOetJJUkw==}
     dependencies:
       inherits: 2.0.4
+    dev: true
+
+  /check-error@1.0.3:
+    resolution: {integrity: sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==}
+    dependencies:
+      get-func-name: 2.0.2
     dev: true
 
   /chokidar@3.5.3:
@@ -7070,6 +7149,13 @@ packages:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
     dev: true
 
+  /deep-eql@4.1.3:
+    resolution: {integrity: sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==}
+    engines: {node: '>=6'}
+    dependencies:
+      type-detect: 4.0.8
+    dev: true
+
   /deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
     engines: {node: '>=4.0.0'}
@@ -7222,6 +7308,11 @@ packages:
   /diff-sequences@27.5.1:
     resolution: {integrity: sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+    dev: true
+
+  /diff-sequences@29.6.3:
+    resolution: {integrity: sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     dev: true
 
   /diff@5.1.0:
@@ -9544,6 +9635,10 @@ packages:
     engines: {node: 6.* || 8.* || >= 10.*}
     dev: true
 
+  /get-func-name@2.0.2:
+    resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
+    dev: true
+
   /get-intrinsic@1.2.1:
     resolution: {integrity: sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==}
     dependencies:
@@ -11671,6 +11766,10 @@ packages:
     hasBin: true
     dev: true
 
+  /jsonc-parser@3.2.0:
+    resolution: {integrity: sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==}
+    dev: true
+
   /jsonfile@2.4.0:
     resolution: {integrity: sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==}
     optionalDependencies:
@@ -11859,6 +11958,11 @@ packages:
 
   /loader.js@4.7.0:
     resolution: {integrity: sha512-9M2KvGT6duzGMgkOcTkWb+PR/Q2Oe54df/tLgHGVmFpAmtqJ553xJh6N63iFYI2yjo2PeJXbS5skHi/QpJq4vA==}
+    dev: true
+
+  /local-pkg@0.4.3:
+    resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
+    engines: {node: '>=14'}
     dev: true
 
   /locate-character@2.0.5:
@@ -12106,6 +12210,12 @@ packages:
     hasBin: true
     dependencies:
       js-tokens: 4.0.0
+    dev: true
+
+  /loupe@2.3.6:
+    resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
+    dependencies:
+      get-func-name: 2.0.2
     dev: true
 
   /lower-case@2.0.2:
@@ -12970,6 +13080,15 @@ packages:
     engines: {node: '>0.9'}
     dev: true
 
+  /mlly@1.4.2:
+    resolution: {integrity: sha512-i/Ykufi2t1EZ6NaPLdfnZk2AX8cs0d+mTzVKuPfqPKPatxLApaBoxJQ9x1/uckXtrS/U5oisPMDkNs0yQTaBRg==}
+    dependencies:
+      acorn: 8.10.0
+      pathe: 1.1.1
+      pkg-types: 1.0.3
+      ufo: 1.3.1
+    dev: true
+
   /morgan@1.10.0:
     resolution: {integrity: sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==}
     engines: {node: '>= 0.8.0'}
@@ -13781,6 +13900,14 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /pathe@1.1.1:
+    resolution: {integrity: sha512-d+RQGp0MAYTIaDBIMmOfMwz3E+LOZnxx1HZd5R18mmCZY0QBlK0LDZfPc8FW8Ed2DlvsuE6PRjroDY+wg4+j/Q==}
+    dev: true
+
+  /pathval@1.1.1:
+    resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
+    dev: true
+
   /picocolors@1.0.0:
     resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
     dev: true
@@ -13824,6 +13951,14 @@ packages:
     engines: {node: '>=14.16'}
     dependencies:
       find-up: 6.3.0
+    dev: true
+
+  /pkg-types@1.0.3:
+    resolution: {integrity: sha512-nN7pYi0AQqJnoLPC9eHFQ8AcyaixBUOwvqc5TDnIKCMEE6I0y8P7OKA7fPexsXGCGxQDl/cmrLAp26LhcwxZ4A==}
+    dependencies:
+      jsonc-parser: 3.2.0
+      mlly: 1.4.2
+      pathe: 1.1.1
     dev: true
 
   /pkg-up@2.0.0:
@@ -13955,6 +14090,15 @@ packages:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+    dev: true
+
+  /pretty-format@29.7.0:
+    resolution: {integrity: sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    dependencies:
+      '@jest/schemas': 29.6.3
+      ansi-styles: 5.2.0
+      react-is: 18.2.0
     dev: true
 
   /pretty-ms@3.2.0:
@@ -14220,6 +14364,10 @@ packages:
 
   /react-is@17.0.2:
     resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+    dev: true
+
+  /react-is@18.2.0:
+    resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: true
 
   /read-pkg-up@9.1.0:
@@ -15166,6 +15314,10 @@ packages:
       object-inspect: 1.12.3
     dev: true
 
+  /siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+    dev: true
+
   /signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
     dev: true
@@ -15468,6 +15620,10 @@ packages:
       escape-string-regexp: 2.0.0
     dev: true
 
+  /stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+    dev: true
+
   /stagehand@1.0.1:
     resolution: {integrity: sha512-GqXBq2SPWv9hTXDFKS8WrKK1aISB0aKGHZzH+uD4ShAgs+Fz20ZfoerLOm8U+f62iRWLrw6nimOY/uYuTcVhvg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -15493,6 +15649,10 @@ packages:
   /statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+    dev: true
+
+  /std-env@3.4.3:
+    resolution: {integrity: sha512-f9aPhy8fYBuMN+sNfakZV18U39PbalgjXG3lLB9WkaYTxijru61wb57V9wxxNthXM5Sd88ETBWi29qLAsHO52Q==}
     dev: true
 
   /stdin-discarder@0.1.0:
@@ -15680,6 +15840,12 @@ packages:
   /strip-json-comments@5.0.1:
     resolution: {integrity: sha512-0fk9zBqO67Nq5M/m45qHCJxylV/DhBlIOVExqgOMiCCrzrhU6tCibRXNqE3jwJLftzE9SNuZtYbpzcO+i9FiKw==}
     engines: {node: '>=14.16'}
+    dev: true
+
+  /strip-literal@1.3.0:
+    resolution: {integrity: sha512-PugKzOsyXpArk0yWmUwqOZecSO0GH0bPoctLcqNDH9J04pVW3lflYE0ujElBGTloevcxF5MofAOZ7C5l2b+wLg==}
+    dependencies:
+      acorn: 8.10.0
     dev: true
 
   /style-loader@2.0.0(webpack@5.88.2):
@@ -16043,6 +16209,20 @@ packages:
       - supports-color
     dev: true
 
+  /tinybench@2.5.1:
+    resolution: {integrity: sha512-65NKvSuAVDP/n4CqH+a9w2kTlLReS9vhsAP06MWx+/89nMinJyB2icyl58RIcqCmIggpojIGeuJGhjU1aGMBSg==}
+    dev: true
+
+  /tinypool@0.7.0:
+    resolution: {integrity: sha512-zSYNUlYSMhJ6Zdou4cJwo/p7w5nmAH17GRfU/ui3ctvjXFErXXkruT4MWW6poDeXgCaIBlGLrfU6TbTXxyGMww==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
+  /tinyspy@2.2.0:
+    resolution: {integrity: sha512-d2eda04AN/cPOR89F7Xv5bK/jrQEhmcLFe6HFldoeO9AJtps+fqEnh486vnT/8y4bw38pSyxDcTCAq+Ks2aJTg==}
+    engines: {node: '>=14.0.0'}
+    dev: true
+
   /titleize@3.0.0:
     resolution: {integrity: sha512-KxVu8EYHDPBdUYdKZdKtU2aj2XfEx9AfjXxE/Aj0vT06w2icA09Vus1rh6eSu1y01akYg6BjIK/hxyLJINoMLQ==}
     engines: {node: '>=12'}
@@ -16368,6 +16548,10 @@ packages:
 
   /uc.micro@1.0.6:
     resolution: {integrity: sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==}
+    dev: true
+
+  /ufo@1.3.1:
+    resolution: {integrity: sha512-uY/99gMLIOlJPwATcMVYfqDSxUR9//AUcgZMzwfSTJPDKzA1S8mX4VLqa+fiAtveraQUBCz4FFcwVZBGbwBXIw==}
     dev: true
 
   /uglify-js@3.17.4:
@@ -16765,7 +16949,29 @@ packages:
       vfile-message: 3.1.4
     dev: true
 
-  /vite@4.4.11:
+  /vite-node@0.34.6(@types/node@20.8.2):
+    resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    dependencies:
+      cac: 6.7.14
+      debug: 4.3.4(supports-color@8.1.1)
+      mlly: 1.4.2
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      vite: 4.4.11(@types/node@20.8.2)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+    dev: true
+
+  /vite@4.4.11(@types/node@20.8.2):
     resolution: {integrity: sha512-ksNZJlkcU9b0lBwAGZGGaZHCMqHsc8OpgtoYhsQ4/I2v5cnpmmmqe5pM4nv/4Hn6G/2GhTdj0DhZh2e+Er1q5A==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -16793,11 +16999,77 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 20.8.2
       esbuild: 0.18.20
       postcss: 8.4.31
       rollup: 3.29.4
     optionalDependencies:
       fsevents: 2.3.3
+    dev: true
+
+  /vitest@0.34.6:
+    resolution: {integrity: sha512-+5CALsOvbNKnS+ZHMXtuUC7nL8/7F1F2DnHGjSsszX8zCjWSSviphCb/NuS9Nzf4Q03KyyDRBAXhF/8lffME4Q==}
+    engines: {node: '>=v14.18.0'}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@vitest/browser': '*'
+      '@vitest/ui': '*'
+      happy-dom: '*'
+      jsdom: '*'
+      playwright: '*'
+      safaridriver: '*'
+      webdriverio: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+      playwright:
+        optional: true
+      safaridriver:
+        optional: true
+      webdriverio:
+        optional: true
+    dependencies:
+      '@types/chai': 4.3.6
+      '@types/chai-subset': 1.3.3
+      '@types/node': 20.8.2
+      '@vitest/expect': 0.34.6
+      '@vitest/runner': 0.34.6
+      '@vitest/snapshot': 0.34.6
+      '@vitest/spy': 0.34.6
+      '@vitest/utils': 0.34.6
+      acorn: 8.10.0
+      acorn-walk: 8.2.0
+      cac: 6.7.14
+      chai: 4.3.10
+      debug: 4.3.4(supports-color@8.1.1)
+      local-pkg: 0.4.3
+      magic-string: 0.30.4
+      pathe: 1.1.1
+      picocolors: 1.0.0
+      std-env: 3.4.3
+      strip-literal: 1.3.0
+      tinybench: 2.5.1
+      tinypool: 0.7.0
+      vite: 4.4.11(@types/node@20.8.2)
+      vite-node: 0.34.6(@types/node@20.8.2)
+      why-is-node-running: 2.2.2
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - sass
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
     dev: true
 
   /vue-template-compiler@2.7.14:
@@ -17042,6 +17314,15 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
+    dev: true
+
+  /why-is-node-running@2.2.2:
+    resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
     dev: true
 
   /wide-align@1.1.5:


### PR DESCRIPTION
While working on https://github.com/mainmatter/qunit-dom/pull/2065
I was reminded that jest does not have adequate TS / ESM support (it still thinks everything is cjs -- and just technically can be set up to work with native ESM, but it's a huuuuge pain, and no one has time for that).

So here is jest replaced by vitest.
I had the option of keeping the "globals" support, but it's better practice to import the things used rather than rely on globals (makes types and eslint easier when imported)

Both before and after this change are 39 test files with 329 tests.
