### PR TITLE
chore(deps): bump release-it-changelog to 6.1.0

### DIFF
--- a/packages/qunit-dom/.release-it.cjs
+++ b/packages/qunit-dom/.release-it.cjs
@@ -2,7 +2,7 @@
 
 module.exports = {
   plugins: {
-    'release-it-lerna-changelog': {
+    '@release-it-plugins/lerna-changelog': {
       infile: 'CHANGELOG.md',
     },
   },

--- a/packages/qunit-dom/package.json
+++ b/packages/qunit-dom/package.json
@@ -56,7 +56,7 @@
     "publint": "0.2.4",
     "qunit": "2.20.1",
     "release-it": "16.2.1",
-    "release-it-lerna-changelog": "5.0.0",
+    "@release-it-plugins/lerna-changelog": "6.1.0",
     "rollup": "2.79.1",
     "rollup-plugin-copy": "3.5.0",
     "rollup-plugin-typescript2": "0.36.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@arethetypeswrong/cli':
         specifier: 0.12.2
         version: 0.12.2
+      '@release-it-plugins/lerna-changelog':
+        specifier: 6.1.0
+        version: 6.1.0(release-it@16.2.1)
       '@types/qunit':
         specifier: 2.19.7
         version: 2.19.7
@@ -74,9 +77,6 @@ importers:
       release-it:
         specifier: 16.2.1
         version: 16.2.1(typescript@5.2.2)
-      release-it-lerna-changelog:
-        specifier: 5.0.0
-        version: 5.0.0(release-it@16.2.1)
       rollup:
         specifier: 2.79.1
         version: 2.79.1
@@ -4511,6 +4511,25 @@ packages:
       '@pnpm/config.env-replace': 1.1.0
       '@pnpm/network.ca-file': 1.0.2
       config-chain: 1.1.13
+    dev: true
+
+  /@release-it-plugins/lerna-changelog@6.1.0(release-it@16.2.1):
+    resolution: {integrity: sha512-zcgiUHiQkqAo1p5HN3xw6+0zmgRs1wzveRreC4CTNs2vErW8L5sCkEZQfSJLd918q+GR43L1/HudjlsiKQK8QA==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      release-it: ^14.0.0 || ^15.1.3 || ^16.0.0 || ^17.0.0
+    dependencies:
+      execa: 5.1.1
+      lerna-changelog: 2.2.0
+      lodash.template: 4.5.0
+      mdast-util-from-markdown: 1.3.1
+      release-it: 16.2.1(typescript@5.2.2)
+      tmp: 0.2.1
+      validate-peer-dependencies: 2.2.0
+      which: 2.0.2
+    transitivePeerDependencies:
+      - bluebird
+      - supports-color
     dev: true
 
   /@rollup/pluginutils@4.2.1:


### PR DESCRIPTION
- release-it-lerna-changelog was renamed to @release-it-plugins/lerna-changelog
- previous release-it-changelog version doesn't work with release-it ^16.