### PR TITLE
Tighter null checks

### DIFF
--- a/packages/qunit-dom/lib/__tests__/does-not-exist.ts
+++ b/packages/qunit-dom/lib/__tests__/does-not-exist.ts
@@ -54,6 +54,21 @@ describe('assert.dom(...).doesNotExist()', () => {
         },
       ]);
     });
+
+    test('fails if passed null', () => {
+      document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
+
+      assert.dom(null).doesNotExist();
+
+      expect(assert.results).toEqual([
+        {
+          actual: 'Element <not found> does not exist',
+          expected: 'Element <not found> does not exist',
+          message: 'Element <not found> does not exist',
+          result: true,
+        },
+      ]);
+    });
   });
 
   test('custom message', () => {

--- a/packages/qunit-dom/lib/__tests__/does-not-have-attribute.ts
+++ b/packages/qunit-dom/lib/__tests__/does-not-have-attribute.ts
@@ -83,6 +83,17 @@ describe('assert.dom(...).doesNotHaveAttribute()', () => {
     ]);
   });
 
+  test('fails for null', () => {
+    assert.dom(null).doesNotHaveAttribute('disabled');
+
+    expect(assert.results).toEqual([
+      {
+        message: 'Element <unknown> should exist',
+        result: false,
+      },
+    ]);
+  });
+
   test('throws for unexpected parameter types', () => {
     //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).doesNotHaveAttribute('disabled')).toThrow('Unexpected Parameter: 5');

--- a/packages/qunit-dom/lib/__tests__/does-not-have-class.ts
+++ b/packages/qunit-dom/lib/__tests__/does-not-have-class.ts
@@ -117,6 +117,17 @@ describe('assert.dom(...).doesNotHaveClass()', () => {
     ]);
   });
 
+  test('fails for null', () => {
+    assert.dom(null).doesNotHaveClass('foo');
+
+    expect(assert.results).toEqual([
+      {
+        message: 'Element <unknown> should exist',
+        result: false,
+      },
+    ]);
+  });
+
   test('throws for unexpected parameter types', () => {
     //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).doesNotHaveClass('foo')).toThrow('Unexpected Parameter: 5');

--- a/packages/qunit-dom/lib/__tests__/does-not-have-style.ts
+++ b/packages/qunit-dom/lib/__tests__/does-not-have-style.ts
@@ -90,6 +90,18 @@ describe('assert.dom(...).doesNotHaveStyle()', () => {
     ]);
   });
 
+  test('fails for null', () => {
+    assert.dom(null).doesNotHaveStyle({
+      opacity: 0,
+    });
+    expect(assert.results).toEqual([
+      {
+        message: 'Element <unknown> should exist',
+        result: false,
+      },
+    ]);
+  });
+
   test('throws for unexpected parameter types', () => {
     //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).doesNotHaveStyle({ opacity: 1 })).toThrow('Unexpected Parameter: 5');

--- a/packages/qunit-dom/lib/__tests__/does-not-match-selector.ts
+++ b/packages/qunit-dom/lib/__tests__/does-not-match-selector.ts
@@ -82,6 +82,21 @@ describe('assert.dom(...).doesNotMatchSelector()', () => {
       ]);
     });
 
+    test('null passed', () => {
+      assert.dom(null).doesNotMatchSelector('div>p:last-child');
+
+      expect(assert.results).toEqual([
+        {
+          actual: '0 elements, selected by null, did not also match the selector div>p:last-child.',
+          expected:
+            '0 elements, selected by null, did not also match the selector div>p:last-child.',
+          message:
+            '0 elements, selected by null, did not also match the selector div>p:last-child.',
+          result: true,
+        },
+      ]);
+    });
+
     test('multiple elements, some matching compareSelector', () => {
       assert.dom('p').doesNotMatchSelector('div>p');
 

--- a/packages/qunit-dom/lib/__tests__/has-any-text.ts
+++ b/packages/qunit-dom/lib/__tests__/has-any-text.ts
@@ -64,6 +64,17 @@ describe('assert.dom(...).hasAnyText()', () => {
     ]);
   });
 
+  test('fails for null', () => {
+    assert.dom(null).hasAnyText();
+
+    expect(assert.results).toEqual([
+      {
+        message: 'Element <unknown> should exist',
+        result: false,
+      },
+    ]);
+  });
+
   test('throws for unexpected parameter types', () => {
     //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasAnyText()).toThrow('Unexpected Parameter: 5');

--- a/packages/qunit-dom/lib/__tests__/has-any-value.ts
+++ b/packages/qunit-dom/lib/__tests__/has-any-value.ts
@@ -65,6 +65,17 @@ describe('assert.dom(...).hasAnyValue()', () => {
     ]);
   });
 
+  test('fails for null', () => {
+    assert.dom(null).hasAnyValue();
+
+    expect(assert.results).toEqual([
+      {
+        message: 'Element <unknown> should exist',
+        result: false,
+      },
+    ]);
+  });
+
   test('throws for unexpected parameter types', () => {
     //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasAnyValue()).toThrow('Unexpected Parameter: 5');

--- a/packages/qunit-dom/lib/__tests__/has-attribute.ts
+++ b/packages/qunit-dom/lib/__tests__/has-attribute.ts
@@ -238,6 +238,17 @@ describe('assert.dom(...).hasAttribute()', () => {
     ]);
   });
 
+  test('fails for null', () => {
+    assert.dom(null).hasAttribute('foo');
+
+    expect(assert.results).toEqual([
+      {
+        message: 'Element <unknown> should exist',
+        result: false,
+      },
+    ]);
+  });
+
   test('throws for unexpected parameter types', () => {
     //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasAttribute('foo')).toThrow('Unexpected Parameter: 5');

--- a/packages/qunit-dom/lib/__tests__/has-class.ts
+++ b/packages/qunit-dom/lib/__tests__/has-class.ts
@@ -112,6 +112,17 @@ describe('assert.dom(...).hasClass()', () => {
     ]);
   });
 
+  test('fails for null', () => {
+    assert.dom(null).hasClass('foo');
+
+    expect(assert.results).toEqual([
+      {
+        message: 'Element <unknown> should exist',
+        result: false,
+      },
+    ]);
+  });
+
   test('throws for unexpected parameter types', () => {
     //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasClass('foo')).toThrow('Unexpected Parameter: 5');

--- a/packages/qunit-dom/lib/__tests__/has-no-text.ts
+++ b/packages/qunit-dom/lib/__tests__/has-no-text.ts
@@ -62,6 +62,17 @@ describe('assert.dom(...).hasNoText()', () => {
     ]);
   });
 
+  test('fails for null', () => {
+    assert.dom(null).hasNoText();
+
+    expect(assert.results).toEqual([
+      {
+        message: 'Element <unknown> should exist',
+        result: false,
+      },
+    ]);
+  });
+
   test('throws for unexpected parameter types', () => {
     //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasNoText()).toThrow('Unexpected Parameter: 5');

--- a/packages/qunit-dom/lib/__tests__/has-no-value.ts
+++ b/packages/qunit-dom/lib/__tests__/has-no-value.ts
@@ -64,6 +64,17 @@ describe('assert.dom(...).hasNoValue()', () => {
     ]);
   });
 
+  test('fails for null', () => {
+    assert.dom(null).hasNoValue();
+
+    expect(assert.results).toEqual([
+      {
+        message: 'Element <unknown> should exist',
+        result: false,
+      },
+    ]);
+  });
+
   test('throws for unexpected parameter types', () => {
     //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasNoValue()).toThrow('Unexpected Parameter: 5');

--- a/packages/qunit-dom/lib/__tests__/has-property.ts
+++ b/packages/qunit-dom/lib/__tests__/has-property.ts
@@ -150,6 +150,17 @@ describe('assert.dom(...).hasProperty()', () => {
     ]);
   });
 
+  test('fails for null', () => {
+    assert.dom(null).hasProperty('foo', 'bar');
+
+    expect(assert.results).toEqual([
+      {
+        message: 'Element <unknown> should exist',
+        result: false,
+      },
+    ]);
+  });
+
   test('throws for unexpected parameter types', () => {
     //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasProperty('foo', 'bar')).toThrow('Unexpected Parameter: 5');

--- a/packages/qunit-dom/lib/__tests__/has-style.ts
+++ b/packages/qunit-dom/lib/__tests__/has-style.ts
@@ -108,6 +108,18 @@ describe('assert.dom(...).hasStyle()', () => {
     ]);
   });
 
+  test('fails for null', () => {
+    assert.dom(null).hasStyle({
+      opacity: 0,
+    });
+    expect(assert.results).toEqual([
+      {
+        message: 'Element <unknown> should exist',
+        result: false,
+      },
+    ]);
+  });
+
   test('throws for unexpected parameter types', () => {
     //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasStyle({ opacity: 1 })).toThrow('Unexpected Parameter: 5');

--- a/packages/qunit-dom/lib/__tests__/has-value.ts
+++ b/packages/qunit-dom/lib/__tests__/has-value.ts
@@ -221,6 +221,17 @@ describe('assert.dom(...).hasValue()', () => {
     ]);
   });
 
+  test('fails for null', () => {
+    assert.dom(null).hasValue('foo');
+
+    expect(assert.results).toEqual([
+      {
+        message: 'Element <unknown> should exist',
+        result: false,
+      },
+    ]);
+  });
+
   test('throws for unexpected parameter types', () => {
     //@ts-ignore -- These assertions are for JavaScript users who don't have type checking
     expect(() => assert.dom(5).hasValue('foo')).toThrow('Unexpected Parameter: 5');

--- a/packages/qunit-dom/lib/__tests__/is-not-visible.ts
+++ b/packages/qunit-dom/lib/__tests__/is-not-visible.ts
@@ -34,6 +34,23 @@ describe('assert.dom(...).isNotVisible()', () => {
     });
   });
 
+  describe('element only', () => {
+    test('succeeds if element is missing', () => {
+      document.body.innerHTML = '<h1 class="baz">foo</h1>bar';
+
+      assert.dom(null).isNotVisible();
+
+      expect(assert.results).toEqual([
+        {
+          actual: 'Element <not found> is not visible',
+          expected: 'Element <not found> is not visible',
+          message: 'Element <not found> is not visible',
+          result: true,
+        },
+      ]);
+    });
+  });
+
   describe('custom messages', () => {
     test('shows custom messages', () => {
       document.body.innerHTML = '<h1 class="baz">foo</h1>bar';

--- a/packages/qunit-dom/lib/__tests__/matches-selector.ts
+++ b/packages/qunit-dom/lib/__tests__/matches-selector.ts
@@ -82,6 +82,19 @@ describe('assert.dom(...).matchesSelector()', () => {
       ]);
     });
 
+    test('null passed', () => {
+      assert.dom(null).matchesSelector('div>p:last-child');
+
+      expect(assert.results).toEqual([
+        {
+          actual: '0 elements, selected by null, also match the selector div>p:last-child.',
+          expected: '0 elements, selected by null, also match the selector div>p:last-child.',
+          message: '0 elements, selected by null, also match the selector div>p:last-child.',
+          result: true,
+        },
+      ]);
+    });
+
     test('multiple elements not all matching compareSelector', () => {
       assert.dom('p').matchesSelector('p + p');
 

--- a/packages/qunit-dom/lib/install.ts
+++ b/packages/qunit-dom/lib/install.ts
@@ -20,11 +20,11 @@ export default function (assert: Assert) {
 
     rootElement = rootElement || this.dom.rootElement || getRootElement();
 
-    if (arguments.length === 0) {
-      target = rootElement instanceof Element ? rootElement : null;
-    }
-
-    return new DOMAssertions(target, rootElement, this);
+    return new DOMAssertions(
+      target !== undefined ? target : rootElement instanceof Element ? rootElement : null,
+      rootElement,
+      this
+    );
   };
 
   function isValidRootElement(element: any): element is Element {

--- a/packages/qunit-dom/lib/root-element.ts
+++ b/packages/qunit-dom/lib/root-element.ts
@@ -1,6 +1,6 @@
 let _getRootElement: () => Element | null = () => null;
 
-export function overrideRootElement(fn: () => Element) {
+export function overrideRootElement(fn: () => Element | null) {
   _getRootElement = fn;
 }
 

--- a/packages/qunit-dom/tsconfig.json
+++ b/packages/qunit-dom/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "noImplicitAny": true,
+    "strictNullChecks": true,
     "declaration": true,
     // Forces import type when imports are only used as types.
     "verbatimModuleSyntax": true,


### PR DESCRIPTION
While looking over #2101 I noticed a bug that it introduced when `matchesSelector()` or `doesNotMatchSelector()` are run on a `null` target, so this PR extends the test coverage to include a `null` target for those assertions as well as all the others that didn't already test that case.

Having `strictNullChecks` enabled also would have caught the bug, and the project was pretty close to being able to enable them, so I made some changes to allow it.

I'm happy to split these out into separate PRs if desired, or change [this syntax](https://github.com/mainmatter/qunit-dom/compare/master...bendemboski:null-checks?expand=1#diff-bfc8336e53c9da7c0c7f5aad909253e36edbea2856e0a90371f29816d20123deR24) if we don't like nested terniary operators 😄 